### PR TITLE
Update OS.cpp

### DIFF
--- a/src/lib/portability/OS.cpp
+++ b/src/lib/portability/OS.cpp
@@ -10,6 +10,7 @@
 #include <cstdio>
 #include <cstring>
 #include <unistd.h>
+#include <ctime>
 #include "../common/Debug.hpp"
 #include "OS.hpp"
 #include <sys/types.h>


### PR DESCRIPTION
On Fedora, with GCC 12.2, the compilation is failing as it can't find "ctime". And following is the build fail message:
```
[ 17%] Building CXX object src/lib/portability/CMakeFiles/numaprof-portability.dir/OS.cpp.o
/tools-perf/numaprof/src/lib/portability/OS.cpp: In static member function ‘static std::string numaprof::OS::getDateTime()’:
/tools-perf/numaprof/src/lib/portability/OS.cpp:118:13: error: ‘time’ was not declared in this scope
  118 |         t = time(NULL);
      |             ^~~~
/tools-perf/numaprof/src/lib/portability/OS.cpp:23:1: note: ‘time’ is defined in header ‘<ctime>’; did you forget to ‘#include <ctime>’?
   22 |         #include <sys/syscall.h>
  +++ |+#include <ctime>
   23 | #endif
/tools-perf/numaprof/src/lib/portability/OS.cpp:119:15: error: ‘localtime’ was not declared in this scope
  119 |         tmp = localtime(&t);
      |               ^~~~~~~~~
/tools-perf/numaprof/src/lib/portability/OS.cpp:119:15: note: ‘localtime’ is defined in header ‘<ctime>’; did you forget to ‘#include <ctime>’?
/tools-perf/numaprof/src/lib/portability/OS.cpp:123:19: error: ‘strftime’ was not declared in this scope
  123 |         int res = strftime(buffer, sizeof(buffer), "%F %R", tmp);
      |                   ^~~~~~~~
/tools-perf/numaprof/src/lib/portability/OS.cpp:123:19: note: ‘strftime’ is defined in header ‘<ctime>’; did you forget to ‘#include <ctime>’?
```